### PR TITLE
Format section numbers with two-digit prefixes - Add Extensions.swift…

### DIFF
--- a/Pocket TMF Reference Model/Pocket TMF Reference Model/Extensions.swift
+++ b/Pocket TMF Reference Model/Pocket TMF Reference Model/Extensions.swift
@@ -1,0 +1,26 @@
+//
+//  Extensions.swift
+//  Pocket TMF Reference Model
+//
+//  Created by Robert Jones on 06/06/2025.
+//
+
+import Foundation
+
+// MARK: - String Extensions
+
+extension String {
+    /// Formats a section number to ensure the first part is always two digits
+    /// Examples: "1.01" -> "01.01", "10.01" -> "10.01"
+    var formattedSectionNumber: String {
+        let components = self.components(separatedBy: ".")
+        guard components.count >= 2,
+              let firstNumber = Int(components[0]) else {
+            return self // Return original if format doesn't match
+        }
+        
+        let formattedFirst = String(format: "%02d", firstNumber)
+        let remaining = components.dropFirst().joined(separator: ".")
+        return "\(formattedFirst).\(remaining)"
+    }
+} 

--- a/Pocket TMF Reference Model/Pocket TMF Reference Model/ZoneDetailView.swift
+++ b/Pocket TMF Reference Model/Pocket TMF Reference Model/ZoneDetailView.swift
@@ -128,7 +128,7 @@ struct SectionHeaderView: View {
                     .font(.headline)
                     .fontWeight(.semibold)
                 
-                Text("Section \(section.number)")
+                Text("Section \(section.number.formattedSectionNumber)")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -161,7 +161,7 @@ struct CollapsibleSectionHeaderView: View {
                         .fontWeight(.semibold)
                         .foregroundColor(.primary)
                     
-                    Text("Section \(section.number)")
+                    Text("Section \(section.number.formattedSectionNumber)")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }


### PR DESCRIPTION
… with formattedSectionNumber computed property - Update ZoneDetailView to display sections as 01.01 instead of 1.01 - Update FiltersView section dropdown to use formatted numbers - Ensures consistent two-digit section number display throughout the app